### PR TITLE
Avoid replicating mDNS messages received on docker0

### DIFF
--- a/rootfs/etc/services.d/mdns/run
+++ b/rootfs/etc/services.d/mdns/run
@@ -3,4 +3,4 @@
 # Start mDNS repeater service
 # ==============================================================================
 
-exec mdns-repeater -f ${ACTIVE_INTERFACE} hassio
+exec mdns-repeater -f ${ACTIVE_INTERFACE} hassio docker0


### PR DESCRIPTION
Currently mdns-repeater replicates all messages received except those
which have the source address of one of the specified interfaces.

When running a service on host network, and that service announces its
addresses on all interfaces via mDNS. Typically, the IN A records
announced on each interface is the address of that interface (e.g.
Apple's mDNSResponder reference implementation behaves that way,
used by OTBR).

Adding docker0 makes sure that docker0 is in the list of interfaces to
replicate to, which makes sure that interfaces from that address are
considered local and not replicated.