### PR TITLE
Only replacate mDNS towards hassio network

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -10,7 +10,7 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  MDNS_REPEATER_VERSION: 1.1.2
+  MDNS_REPEATER_VERSION: 1.2.0
 labels:
   io.hass.type: multicast
   org.opencontainers.image.source: https://github.com/home-assistant/plugin-multicast

--- a/rootfs/etc/cont-init.d/interface.sh
+++ b/rootfs/etc/cont-init.d/interface.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/with-contenv bashio
-# ==============================================================================
-# Detect active interface for mdns repeater
-# ==============================================================================
-interface=$(awk '{for (i=1; i<=NF; i++) if ($i~/dev/) print $(i+1)}' <<< "$(ip route get 8.8.8.8)")
-
-echo "${interface}" > /var/run/s6/container_environment/ACTIVE_INTERFACE

--- a/rootfs/etc/services.d/mdns/run
+++ b/rootfs/etc/services.d/mdns/run
@@ -3,4 +3,4 @@
 # Start mDNS repeater service
 # ==============================================================================
 
-exec mdns-repeater -f ${ACTIVE_INTERFACE} hassio docker0
+exec mdns-repeater -f hassio


### PR DESCRIPTION
So far, all interfaces have been specified. This replicates all
mDNS messages received on the hassio network interface towards the
outside interface, and all mDNS messages received on the external
interface towards hassio.

However, this does not work well in two cases:
- When an additional interface is present: mdns-repeater listens on
  any mDNS messages. If an additional interface is present, messages
  from that interface get replicated on the main Ethernet interface.
  This is problematic when there already exists a router which
  replicates the messages between the two networks.
- When multiple subnets are present on one interface: mdns-repeater
  matches the senders IP address with the interface IP/mask to determine
  if the mDNS message has been received from a particular interface.
  If multiple IPs are present, or mDNS messages originate for some other
  reason not from the same IP network as the local interface is
  configured for, mdns-repeater starts to replicate messages received on
  the same interface.

The last problem has been improved by also checking the received
interface (besides sender IP), which should avoid this type of
replication.

However, replicating mDNS messages from the internal hassio network to
the Ethernet is in almost all cases not helpful anyways: Typically mDNS
responder use the local interface address to generate mDNS A records.
The local address from an add-on attached ot the hassio network is not
helpful in the extenal network.

By only specifying the hassio network mdns-repeater will continue to
listen on all interfaces, but only replicate mDNS messages towards
hassio.

Fixes #1.